### PR TITLE
Make the parameters nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $connection->setOauthClient(true);
 
 $connection->setClientId('your-client-id')
     ->setClientSecret('your-client-secret')
-    ->setRedirectUrl('your-callback-url');
+    ->setRedirectUrl('your-callback-url')
     ->setTokenUpdateCallback(function (\Sendy\Api\Connection $connection) {
         $data = [
             'access_token' => $connection->getAccessToken(),

--- a/src/Resources/Label.php
+++ b/src/Resources/Label.php
@@ -13,15 +13,15 @@ final class Label extends Resource
      * Get a combined PDF with labels of all packages in the given shipments
      *
      * @param non-empty-array<string> $shipmentIds The ids of the shipments
-     * @param 'A4'|'A6' $paperType The paper size to combine the labels on
-     * @param 'top-left'|'top-right'|'bottom-left'|'bottom-right' $startLocation Where to start combining the labels.
-     *                                                                           Used when $paperType is set to A4.
+     * @param null|'A4'|'A6' $paperType The paper size to combine the labels on
+     * @param null|'top-left'|'top-right'|'bottom-left'|'bottom-right' $startLocation Where to start combining the
+     *  labels. Only used when $paperType is set to A4.
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
      * @see https://app.sendy.nl/api/docs#tag/Documents/operation/getLabels
      */
-    public function get(array $shipmentIds, string $paperType = 'A6', string $startLocation = 'top-left'): array
+    public function get(array $shipmentIds, string $paperType = null, string $startLocation = null): array
     {
         $params = [
             'ids' => $shipmentIds,

--- a/tests/Resources/LabelTest.php
+++ b/tests/Resources/LabelTest.php
@@ -24,7 +24,25 @@ class LabelTest extends TestCase
         $this->assertEquals([], $resource->get(['123456']));
 
         $this->assertEquals(
-            '/api/labels?ids%5B0%5D=123456&paper_type=A6&start_location=top-left',
+            '/api/labels?ids%5B0%5D=123456',
+            (string) $handler->getLastRequest()->getUri()
+        );
+
+        $this->assertEquals('GET', $handler->getLastRequest()->getMethod());
+    }
+
+    public function testParametersAreSetInURL(): void
+    {
+        $handler = new MockHandler([
+            new Response(200, [], json_encode([])),
+        ]);
+
+        $resource = new Label($this->buildConnectionWithMockHandler($handler));
+
+        $this->assertEquals([], $resource->get(['123456', 'A4', 'top-left']));
+
+        $this->assertEquals(
+            '/api/labels?ids%5B0%5D=123456&ids%5B1%5D=A4&ids%5B2%5D=top-left',
             (string) $handler->getLastRequest()->getUri()
         );
 


### PR DESCRIPTION
The parameters are optional in the API, but where required in the SDK. By making the parameters nullable the SDK will now fallback to the user settings from the application when no paper type is selected.