### PR TITLE
Mark long-lived tokens as expired after July 1st

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -289,6 +289,12 @@ class Connection
 
     public function tokenHasExpired(): bool
     {
+        // Starting July 1st, 2025 only short-lived access tokens will be issued from the API. This will invalidate all
+        // tokens issued before July 1st with a lifespan longer than 10 minutes.
+        if (time() > 1751320800 && $this->tokenExpires > time() + 600) {
+            return true;
+        }
+
         return $this->tokenExpires - 10 < time();
     }
 


### PR DESCRIPTION
After July 1st, 2025 the API will stop issuing long-lived access tokens and existing tokens will be revoked. The SDK will automatically refresh all access tokens which expire more than 10 minutes in the future after July 1st.