### PR TITLE
Update documentation links

### DIFF
--- a/src/Resources/Carrier.php
+++ b/src/Resources/Carrier.php
@@ -15,7 +15,7 @@ final class Carrier extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Carriers/operation/getCarriers
+     * @link https://app.sendy.nl/api/docs#tag/Carriers/operation/api.carriers.index
      */
     public function list(): array
     {
@@ -31,7 +31,7 @@ final class Carrier extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
-     * @see https://app.sendy.nl/api/docs#tag/Carriers/operation/getCarrier
+     * @link https://app.sendy.nl/api/docs#tag/Carriers/operation/api.carriers.show
      */
     public function get(int $id): array
     {

--- a/src/Resources/Label.php
+++ b/src/Resources/Label.php
@@ -19,7 +19,7 @@ final class Label extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Documents/operation/getLabels
+     * @link https://app.sendy.nl/api/docs#tag/Documents/operation/api.labels.index
      */
     public function get(array $shipmentIds, string $paperType = null, string $startLocation = null): array
     {

--- a/src/Resources/Me.php
+++ b/src/Resources/Me.php
@@ -9,7 +9,7 @@ final class Me extends Resource
      *
      * Display the currently authenticated user’s profile.
      *
-     * @see https://app.sendy.nl/api/docs#tag/User/operation/getProfileInformation
+     * @link https://app.sendy.nl/api/docs#tag/User/operation/api.me
      * @return array<string, mixed|array<string|mixed>>
      */
     public function get(): array

--- a/src/Resources/Parcelshop.php
+++ b/src/Resources/Parcelshop.php
@@ -20,7 +20,7 @@ class Parcelshop extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Parcel-shops
+     * @link https://app.sendy.nl/api/docs#tag/Parcel-shops
      */
     public function list(
         array $carriers,

--- a/src/Resources/Service.php
+++ b/src/Resources/Service.php
@@ -16,7 +16,7 @@ class Service extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Services/operation/getCarrierServices
+     * @link https://app.sendy.nl/api/docs#tag/Services/operation/api.carriers.services.index
      */
     public function list(int $carrierId): array
     {

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -17,7 +17,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Shipments/operation/shipments.index
+     * @link https://app.sendy.nl/api/docs#tag/Shipments/operation/api.shipments.index
      * @see Meta
      */
     public function list(int $page = 1): array
@@ -34,7 +34,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Shipments/operation/shipments.show
+     * @link https://app.sendy.nl/api/docs#tag/Shipments/operation/api.shipments.show
      */
     public function get(string $id): array
     {
@@ -70,7 +70,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Shipments/operation/shipments.destroy
+     * @link https://app.sendy.nl/api/docs#tag/Shipments/operation/api.shipments.destroy
      */
     public function delete(string $id): array
     {
@@ -87,7 +87,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
-     * @see https://app.sendy.nl/api/docs#tag/Shipments/operation/shipments.preference
+     * @link https://app.sendy.nl/api/docs#tag/Shipments/operation/api.shipments.preference
      * @see ShippingPreference
      */
     public function createFromPreference(array $data, bool $generateDirectly = true): array
@@ -102,7 +102,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
-     * @see https://app.sendy.nl/api/docs#tag/Shipments/operation/shipments.smart-rule
+     * @link https://app.sendy.nl/api/docs#tag/Shipments/operation/api.shipments.smart-rule
      */
     public function createWithSmartRules(array $data): array
     {
@@ -119,7 +119,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
-     * @see https://app.sendy.nl/api/docs#tag/Shipments/operation/shipments.generate
+     * @link https://app.sendy.nl/api/docs#tag/Shipments/operation/api.shipments.generate
      */
     public function generate(string $id, bool $asynchronous = true): array
     {
@@ -135,7 +135,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
-     * @see https://app.sendy.nl/api/docs#tag/Documents/operation/getLabels
+     * @link https://app.sendy.nl/api/docs#tag/Documents/operation/api.shipments.labels.index
      */
     public function labels(string $id): array
     {
@@ -151,7 +151,7 @@ final class Shipment extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
-     * @see https://app.sendy.nl/api/docs#tag/Documents/operation/shipments.documents
+     * @link https://app.sendy.nl/api/docs#tag/Documents/operation/api.shipments.documents.index
      */
     public function documents(string $id): array
     {

--- a/src/Resources/ShippingPreference.php
+++ b/src/Resources/ShippingPreference.php
@@ -12,7 +12,7 @@ class ShippingPreference extends Resource
      *
      * Display all active shipping preferences for the active company in a list.
      *
-     * @see https://app.sendy.nl/api/docs#tag/Shipping-preferences/operation/shipping_preferences.index
+     * @link https://app.sendy.nl/api/docs#tag/Shipping-preferences
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException

--- a/src/Resources/Shop.php
+++ b/src/Resources/Shop.php
@@ -12,7 +12,7 @@ class Shop extends Resource
      *
      * Display all shops in a list
      *
-     * @see https://app.sendy.nl/api/docs#tag/Shops/operation/getShops
+     * @link https://app.sendy.nl/api/docs#tag/Shops/operation/api.shops.index
      * @return array<string, mixed|array<string|mixed>>
      * @throws GuzzleException
      * @throws ApiException
@@ -27,7 +27,7 @@ class Shop extends Resource
      *
      * Get a specific shop by its UUID
      *
-     * @see https://app.sendy.nl/api/docs#tag/Shops/operation/getShopByUuid
+     * @link https://app.sendy.nl/api/docs#tag/Shops/operation/api.shops.show
      * @param string $id
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException

--- a/src/Resources/Webhook.php
+++ b/src/Resources/Webhook.php
@@ -10,7 +10,7 @@ final class Webhook extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Sendy\Api\ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Webhooks/operation/api.webhooks.index
+     * @link https://app.sendy.nl/api/docs#tag/Webhooks/operation/api.webhooks.index
      */
     public function list(): array
     {
@@ -24,7 +24,7 @@ final class Webhook extends Resource
      * @return array<string, mixed|array<string|mixed>>
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Sendy\Api\ApiException
-     * @see https://app.sendy.nl/api/docs#tag/Webhooks/operation/api.webhooks.store
+     * @link https://app.sendy.nl/api/docs#tag/Webhooks/operation/api.webhooks.store
      */
     public function create(array $data): array
     {


### PR DESCRIPTION
Update the URLs to the endpoint documentation and use the [`@link`](https://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_tags.link.pkg.html) doctag