### PR TITLE
prevent implicit nullable deprecation errors in php 8.4

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -13,7 +13,7 @@ final class ApiException extends \Exception
      * @param \Throwable|null $previous
      * @param string[][] $errors
      */
-    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null, array $errors = [])
+    public function __construct(string $message = "", int $code = 0, ?\Throwable $previous = null, array $errors = [])
     {
         $this->errors = $errors;
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -355,8 +355,8 @@ class Connection
         string $method,
         string $endpoint,
         $body = null,
-        array $params = null,
-        array $headers = null
+        ?array $params = null,
+        ?array $headers = null
     ): Request {
         $headers = array_merge($headers, [
             'Accept'       => 'application/json',
@@ -394,14 +394,14 @@ class Connection
 
     /**
      * @param UriInterface|string $url
-     * @param array<string, mixed|mixed[]> $body
+     * @param array<string, mixed|mixed[]>|null $body
      * @param array<string, mixed|mixed[]> $params
      * @param array<string, mixed|mixed[]> $headers
      * @return array<string, mixed|array<string|mixed>>
      * @throws ApiException
      * @throws GuzzleException
      */
-    public function post($url, array $body = null, array $params = [], array $headers = []): array
+    public function post($url, ?array $body = null, array $params = [], array $headers = []): array
     {
         $url = self::API_URL . $url;
 


### PR DESCRIPTION
Prevent following errors from the php linter in PHP8.4:

PHP Deprecated:  Sendy\Api\ApiException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/ApiException.php on line 16

Deprecated: Sendy\Api\ApiException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/ApiException.php on line 16
No syntax errors detected in vendor/sendynl/php-sdk/src/ApiException.php
PHP Deprecated:  Sendy\Api\Connection::createRequest(): Implicitly marking parameter $params as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/Connection.php on line 354

Deprecated: Sendy\Api\Connection::createRequest(): Implicitly marking parameter $params as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/Connection.php on line 354
PHP Deprecated:  Sendy\Api\Connection::createRequest(): Implicitly marking parameter $headers as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/Connection.php on line 354

Deprecated: Sendy\Api\Connection::createRequest(): Implicitly marking parameter $headers as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/Connection.php on line 354
PHP Deprecated:  Sendy\Api\Connection::post(): Implicitly marking parameter $body as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/Connection.php on line 404

Deprecated: Sendy\Api\Connection::post(): Implicitly marking parameter $body as nullable is deprecated, the explicit nullable type must be used instead in vendor/sendynl/php-sdk/src/Connection.php on line 404
No syntax errors detected in vendor/sendynl/php-sdk/src/Connection.php
No syntax errors detected in vendor/sendynl/php-sdk/src/Meta.php
No syntax errors detected in vendor/sendynl/php-sdk/src/RateLimits.php
